### PR TITLE
Added tutorial on using torch optimizer with heyoka

### DIFF
--- a/doc/notebooks/torch_and_heyoka.ipynb
+++ b/doc/notebooks/torch_and_heyoka.ipynb
@@ -734,7 +734,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Simple fixed learning rate stochastic gradient descent"
+    "Simple fixed learning rate stochastic gradient descent"
    ]
   },
   {
@@ -863,7 +863,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Now we do the same training with the Adam Optimizer"
+    "Now we do the same training with the Adam Optimizer"
    ]
   },
   {


### PR DESCRIPTION
I added to the already existing tutorial "torch_and_heyoka.ipynb" a section on using the Adam optimizer from torch. I use a simplified case of the Neural ODE training tutorials to showcase the difference between simple fixed learning rate stochastic gradient descent and training with the Adam optimizer.

Extrapolating this tutorial to other torch optimizers and the use of schedulers should be straightforward.